### PR TITLE
Revert "No need to include the headers manually"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include README.md COPYING LICENSE
 include Makefile source/Makefile
 include requirements.txt
 
-recursive-include source *.h
+recursive-include libpsautohint *.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.md COPYING LICENSE
 include Makefile source/Makefile
 include requirements.txt
+
+recursive-include source *.h


### PR DESCRIPTION
actually, that's not true.
We still need to include *.h in the MANIFEST otherwise I get this when building from a sdist zip:

```
python/psautohint/_psautohint.c:33:10: fatal error: 'psautohint.h' file not found
```

This reverts commit 0cbe820faf45f878ef4357696ef8968ec405aea2.